### PR TITLE
Provide a full DATABASE_URL with all the components

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -60,15 +60,20 @@ echo "-----> Initializing database"
 export PGHOST=/tmp
 DATABASE=postgres-buildpack-db
 
-# Start database for Heroku CI
+# Set up and configure a database for Heroku CI
+user="u$(</dev/urandom tr -dc 'a-z0-9' | head -c 13)"
+password="p$(</dev/urandom tr -dc 'a-z0-9' | head -c 64)"
+
 PG_DATA_DIR=$BUILD_DIR/vendor/postgresql/data
 initdb -D $PG_DATA_DIR | indent
 pg_ctl -D $PG_DATA_DIR -l .pg.log start | indent
 sleep 1
-createdb $DATABASE | indent
+psql -c "CREATE USER ${user} WITH SUPERUSER ENCRYPTED PASSWORD '${password}'" postgres | indent
+createdb --owner $user $DATABASE | indent
+DATABASE_URL="postgres://${user}:${password}@localhost:5432/${DATABASE}"
 
 echo "export PGHOST=$PGHOST" >> $BUILDPACK_DIR/export
-echo "export DATABASE_URL=postgres:///$DATABASE" >> $BUILDPACK_DIR/export
+echo "export DATABASE_URL=$DATABASE_URL" >> $BUILDPACK_DIR/export
 
 # setting .profile.d script for database startup
 echo "-----> Copying .profile.d/pg.sh to add postgresql binaries to PATH"
@@ -78,9 +83,12 @@ PATH=$HOME/vendor/postgresql/bin:$PATH
 
 export PGHOST=/tmp
 export PG_DATA_DIR=$HOME/vendor/postgresql/data
-export DATABASE_URL="postgres:///postgres-buildpack-db"
 
 pg_ctl -D $PG_DATA_DIR -l .pg.log start
+EOF
+
+cat<<EOF > $BUILD_DIR/.profile.d/pg-env.sh
+export DATABASE_URL="$DATABASE_URL"
 EOF
 
 echo "-----> postgresql done"


### PR DESCRIPTION
It seems that some libraries (specifically, node's Sequelize in my
case) get confused by partial URLs in some situations. This is also
closer to what Heroku Postgres provides.