### PR TITLE
Minor cleanup

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -64,9 +64,9 @@ DATABASE=postgres-buildpack-db
 user="u$(</dev/urandom tr -dc 'a-z0-9' | head -c 13)"
 password="p$(</dev/urandom tr -dc 'a-z0-9' | head -c 64)"
 
-PG_DATA_DIR=$BUILD_DIR/vendor/postgresql/data
-initdb -D $PG_DATA_DIR | indent
-pg_ctl -D $PG_DATA_DIR -l .pg.log -w start | indent
+PGDATA=$BUILD_DIR/vendor/postgresql/data
+initdb -D $PGDATA | indent
+pg_ctl -D $PGDATA -l .pg.log -w start | indent
 psql -c "CREATE USER ${user} WITH SUPERUSER ENCRYPTED PASSWORD '${password}'" postgres | indent
 createdb --owner $user $DATABASE | indent
 DATABASE_URL="postgres://${user}:${password}@localhost:5432/${DATABASE}"
@@ -81,9 +81,9 @@ cat<<\EOF > $BUILD_DIR/.profile.d/pg-path.sh
 PATH=$HOME/vendor/postgresql/bin:$PATH
 
 export PGHOST=/tmp
-export PG_DATA_DIR=$HOME/vendor/postgresql/data
+export PGDATA=$HOME/vendor/postgresql/data
 
-pg_ctl -D $PG_DATA_DIR -l .pg.log -w start
+pg_ctl -D $PGDATA -l .pg.log -w start
 EOF
 
 cat<<EOF > $BUILD_DIR/.profile.d/pg-env.sh

--- a/bin/compile
+++ b/bin/compile
@@ -70,6 +70,8 @@ pg_ctl -D $PGDATA -l .pg.log -w start | indent
 psql -c "CREATE USER ${user} WITH SUPERUSER ENCRYPTED PASSWORD '${password}'" postgres | indent
 createdb --owner $user $DATABASE | indent
 DATABASE_URL="postgres://${user}:${password}@localhost:5432/${DATABASE}"
+# N.B.: we do not stop the server here because some buildpacks rely on
+# having a live database at DATABASE_URL in order to run the build
 
 echo "export PGHOST=$PGHOST" >> $BUILDPACK_DIR/export
 echo "export DATABASE_URL=$DATABASE_URL" >> $BUILDPACK_DIR/export
@@ -83,7 +85,10 @@ PATH=$HOME/vendor/postgresql/bin:$PATH
 export PGHOST=/tmp
 export PGDATA=$HOME/vendor/postgresql/data
 
-pg_ctl -D $PGDATA -l .pg.log -w start
+if ! pg_ctl -D $PGDATA status >/dev/null;
+then
+  pg_ctl -D $PGDATA -l .pg.log -w start
+fi
 EOF
 
 cat<<EOF > $BUILD_DIR/.profile.d/pg-env.sh

--- a/bin/compile
+++ b/bin/compile
@@ -64,9 +64,9 @@ DATABASE=postgres-buildpack-db
 user="u$(</dev/urandom tr -dc 'a-z0-9' | head -c 13)"
 password="p$(</dev/urandom tr -dc 'a-z0-9' | head -c 64)"
 
-PGDATA=$BUILD_DIR/vendor/postgresql/data
-initdb -D $PGDATA | indent
-pg_ctl -D $PGDATA -l .pg.log -w start | indent
+export PGDATA=$BUILD_DIR/vendor/postgresql/data
+initdb | indent
+pg_ctl -l .pg.log -w start | indent
 psql -c "CREATE USER ${user} WITH SUPERUSER ENCRYPTED PASSWORD '${password}'" postgres | indent
 createdb --owner $user $DATABASE | indent
 DATABASE_URL="postgres://${user}:${password}@localhost:5432/${DATABASE}"
@@ -85,9 +85,9 @@ PATH=$HOME/vendor/postgresql/bin:$PATH
 export PGHOST=/tmp
 export PGDATA=$HOME/vendor/postgresql/data
 
-if ! pg_ctl -D $PGDATA status >/dev/null;
+if ! pg_ctl status >/dev/null;
 then
-  pg_ctl -D $PGDATA -l .pg.log -w start
+  pg_ctl -l .pg.log -w start
 fi
 EOF
 


### PR DESCRIPTION
 * Use `PGDATA` instead of `PG_DATA_DIR` since the former is a standard Postgres env var with the same semantics
 * Add comment to explain why we can't just stop the Postgres server we start after setting it up and rely on our .profile script to start it again
 * Don't start the server again if one is already running