### PR TITLE
Gotta go fast

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -67,6 +67,7 @@ password="p$(</dev/urandom tr -dc 'a-z0-9' | head -c 64)"
 export PGDATA=$BUILD_DIR/vendor/postgresql/data
 initdb | indent
 echo "fsync = off" >> $PGDATA/postgresql.conf
+echo "full_page_writes = off" >> $PGDATA/postgresql.conf
 
 pg_ctl -l .pg.log -w start | indent
 psql -c "CREATE USER ${user} WITH SUPERUSER ENCRYPTED PASSWORD '${password}'" postgres | indent

--- a/bin/compile
+++ b/bin/compile
@@ -66,6 +66,8 @@ password="p$(</dev/urandom tr -dc 'a-z0-9' | head -c 64)"
 
 export PGDATA=$BUILD_DIR/vendor/postgresql/data
 initdb | indent
+echo "fsync = off" >> $PGDATA/postgresql.conf
+
 pg_ctl -l .pg.log -w start | indent
 psql -c "CREATE USER ${user} WITH SUPERUSER ENCRYPTED PASSWORD '${password}'" postgres | indent
 createdb --owner $user $DATABASE | indent


### PR DESCRIPTION
There is little benefit to keeping crash-safety in an ephemeral in-dyno database, and turning off fsync can make use cases like specs run faster.

The [`fsync`](https://www.postgresql.org/docs/9.6/static/runtime-config-wal.html#GUC-FSYNC) section in the Postgres docs has more detail.