### PR TITLE
Do not fail silently on unknown stack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -45,6 +45,12 @@ function package_download() {
 }
 
 echo "Using postgresql version: ${POSTGRESQL_VERSION}" | indent
+
+case $STACK in
+    cedar-14) : ;;
+    *) error "Unrecognized stack version: ${STACK}";;
+esac
+
 echo "Using stack version: ${STACK}" | indent
 
 # vendor directories


### PR DESCRIPTION
Because Heroku switched the default stack from cedar-14 to heroku-16,
and there are no heroku-16 Postgres binaries in the buildpack's
bucket, and the buildpack doesn't handle errors in fetching the
binaries gracefully, it currently generates an ugly error:

```
       Using stack version: heroku-16
-----> Fetching and vendoring postgresql into slug
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

This handles the "unknown stack" situation better.

[1]: https://devcenter.heroku.com/changelog-items/1139