### PR TITLE
Allow heroku-16-build stack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -48,6 +48,8 @@ echo "Using postgresql version: ${POSTGRESQL_VERSION}" | indent
 
 case $STACK in
     cedar-14) : ;;
+    heroku-16) : ;;
+    heroku-16-build) : ;;
     *) error "Unrecognized stack version: ${STACK}";;
 esac
 


### PR DESCRIPTION
I've uploaded a heroku-16-build version to the s3 bucket so we can allow it in the buildpack now.